### PR TITLE
fix order of authToken/session-id for external authentication URLs

### DIFF
--- a/doc_source/external-authentication.md
+++ b/doc_source/external-authentication.md
@@ -38,7 +38,7 @@ You must configure the NICE DCV server to use the external authentication servic
 Once you have generated the token, you must be able to send it to the NICE DCV server\. With the web browser client, append the token to the connection URL as follows:
 
 ```
-https://server_hostname_or_IP:port/authTo?authToken=1234567890abcdefken=token#session_id?
+https://server_hostname_or_IP:port/?authToken=token#session_id
 ```
 
 For example:

--- a/doc_source/external-authentication.md
+++ b/doc_source/external-authentication.md
@@ -38,13 +38,13 @@ You must configure the NICE DCV server to use the external authentication servic
 Once you have generated the token, you must be able to send it to the NICE DCV server\. With the web browser client, append the token to the connection URL as follows:
 
 ```
-https://server_hostname_or_IP:port/#session_id?authToken=token
+https://server_hostname_or_IP:port/authTo?authToken=1234567890abcdefken=token#session_id?
 ```
 
 For example:
 
 ```
-https://my-dcv-server.com:8443/#my-session?authToken=1234567890abcdef
+https://my-dcv-server.com:8443/?authToken=1234567890abcdef#my-session
 ```
 
 ## Authentication service requirements<a name="configure-authenticator"></a>


### PR DESCRIPTION
The GET parameter has to come *before* the anchor